### PR TITLE
Fix/opensourcecard unlock not triggering

### DIFF
--- a/client/src/components/LockedEmployeeCard.jsx
+++ b/client/src/components/LockedEmployeeCard.jsx
@@ -18,8 +18,10 @@ export function LockedEmployeeCard({ config, progress }) {
     switch (condition.type) {
       case "TOTAL_LOC":
         return `Earn ${condition.required} total lines of code`;
-      case "EMPLOYEE_COUNT":
+      case "TOTAL_EMPLOYEE_COUNT":
         return `Hire ${condition.required} employees`;
+      case "SPECIFIC_EMPLOYEE_COUNT":
+        return `Hire ${condition.required} ${condition.employeeType}${condition.required > 1 ? "s" : ""}`;
       default:
         return "Complete an unknown objective";
     }

--- a/client/src/components/LockedEmployeeCard.jsx
+++ b/client/src/components/LockedEmployeeCard.jsx
@@ -46,7 +46,7 @@ export function LockedEmployeeCard({ config, progress }) {
               <ProgressBar
                 key={idx}
                 current={prog.current}
-                required={prog.required}
+                target={prog.target}
                 label={formatCondition(prog)}
               />
             );

--- a/client/src/components/LockedEmployeeCard.jsx
+++ b/client/src/components/LockedEmployeeCard.jsx
@@ -11,22 +11,9 @@
 
 import { formatMoney } from "../utils/currency";
 import { ProgressBar } from "./ProgressBar.jsx";
+import { formatCondition } from "../utils/formatCondition.js";
 
 export function LockedEmployeeCard({ config, progress }) {
-  // Format unlock condition for human-readable display
-  const formatCondition = (condition) => {
-    switch (condition.type) {
-      case "TOTAL_LOC":
-        return `Earn ${condition.required} total lines of code`;
-      case "TOTAL_EMPLOYEE_COUNT":
-        return `Hire ${condition.required} employees`;
-      case "SPECIFIC_EMPLOYEE_COUNT":
-        return `Hire ${condition.required} ${condition.employeeType}${condition.required > 1 ? "s" : ""}`;
-      default:
-        return "Complete an unknown objective";
-    }
-  };
-
   // Calculate if all conditions are met (derived state, not stored)
   // Guard against empty progress array as defensive measure, though in practice
   // this component is only rendered for locked employees with non-empty progress.

--- a/client/src/components/LockedOpenSourceCard.jsx
+++ b/client/src/components/LockedOpenSourceCard.jsx
@@ -1,9 +1,9 @@
 import { formatMoney } from "../utils/currency";
 import { ProgressBar } from "./ProgressBar.jsx";
+import { formatCondition } from "../utils/formatCondition.js";
 
 export function LockedOpenSourceCard({
   project,
-  unlockConditions,
   progress,
   nextBonus,
   locCost,
@@ -49,9 +49,7 @@ export function LockedOpenSourceCard({
                     key={index}
                     current={prog.current}
                     required={prog.required}
-                    label={`Hire ${prog.required} ${
-                      unlockConditions[index].employeeType
-                    }${prog.required > 1 ? "s" : ""}`}
+                    label={formatCondition(prog)}
                   />
                 ))}
               </div>

--- a/client/src/components/LockedOpenSourceCard.jsx
+++ b/client/src/components/LockedOpenSourceCard.jsx
@@ -48,7 +48,7 @@ export function LockedOpenSourceCard({
                   <ProgressBar
                     key={index}
                     current={prog.current}
-                    required={prog.required}
+                    target={prog.target}
                     label={formatCondition(prog)}
                   />
                 ))}

--- a/client/src/components/OpenSource.jsx
+++ b/client/src/components/OpenSource.jsx
@@ -36,7 +36,6 @@ export function OpenSource() {
             <LockedOpenSourceCard
               key={id}
               project={config}
-              unlockConditions={config.unlockConditions}
               progress={progress}
               nextBonus={config.levels[0]?.bonus}
               locCost={config.levels[0]?.locCost}

--- a/client/src/components/OpenSourceCard.jsx
+++ b/client/src/components/OpenSourceCard.jsx
@@ -66,7 +66,7 @@ export function OpenSourceCard({
                   </span>
                 </div>
               ) : (
-                <span className="comment-text">// MAXED OUT</span>
+                <div className="comment-text">// MAXED OUT</div>
               )}
 
               {/* ending comment tag */}

--- a/client/src/components/ProgressBar.jsx
+++ b/client/src/components/ProgressBar.jsx
@@ -1,16 +1,15 @@
-export function ProgressBar({ current, required, label }) {
-  const percentage =
-    required > 0 ? Math.min((current / required) * 100, 100) : 0;
+export function ProgressBar({ current, target, label }) {
+  const percentage = target > 0 ? Math.min((current / target) * 100, 100) : 0;
 
   return (
     <div className="space-y-1">
       <div className="flex flex-col justify-between items-start">
         <span className="text-xs">
           {label}
-          {current < required && (
+          {current < target && (
             <span className="text-gray-400">
               {" "}
-              ({required - current} remaining)
+              ({target - current} remaining)
             </span>
           )}
         </span>
@@ -21,7 +20,7 @@ export function ProgressBar({ current, required, label }) {
         role="progressbar"
         aria-valuenow={current}
         aria-valuemin="0"
-        aria-valuemax={required}
+        aria-valuemax={target}
         aria-label={label}
       >
         <div
@@ -29,7 +28,7 @@ export function ProgressBar({ current, required, label }) {
           style={{ width: `${percentage}%` }}
         />
         <span className="absolute inset-0 flex items-center justify-center text-xs text-white">
-          {current} / {required}
+          {current} / {target}
         </span>
       </div>
     </div>

--- a/client/src/components/StatDisplay.jsx
+++ b/client/src/components/StatDisplay.jsx
@@ -25,7 +25,7 @@ export const StatDisplay = forwardRef(function StatDisplay(
   ref
 ) {
   return (
-    <div ref={ref} className="flex flex-1 flex-col items-center">
+    <div ref={ref} className="flex flex-col items-center w-20">
       <span>{icon}</span>
 
       <span className="">{value}</span>

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -994,7 +994,7 @@ export function getUnlockProgressForOpenSource(projectId, state) {
         current = 0;
     }
 
-    const target = condition.target; // Note: uses 'target' not 'value' like employees
+    const target = condition.target;
     const remaining = Math.max(0, target - current);
 
     return {

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -896,7 +896,7 @@ export function isEmployeeUnlocked(employeeType, state) {
  * getUnlockProgress("senior", state)
  * // Returns: [
  * //   { type: "TOTAL_LOC", current: 2000, target: 3000, remaining: 1000 },
- * //   { type: "EMPLOYEE_COUNT", current: 5, target: 10, remaining: 5 }
+ * //   { type: "TOTAL_EMPLOYEE_COUNT", current: 5, target: 10, remaining: 5 }
  * // ]
  */
 export function getUnlockProgress(employeeType, state) {

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -681,8 +681,8 @@ export function calculateLOCPerSecond(state) {
  * Used internally by areUnlockConditionsMet(). NOT exported.
  *
  * @param {Object} condition - The condition to check
- * @param {string} condition.type - Type of condition (e.g., "TOTAL_LOC", "EMPLOYEE_COUNT")
- * @param {number} condition.value - The threshold value
+ * @param {string} condition.type - Type of condition (e.g., "TOTAL_LOC", "TOTAL_EMPLOYEE_COUNT", "SPECIFIC_EMPLOYEE_COUNT")
+ * @param {number} condition.target - The threshold value
  * @param {Object} state - The game state to check against
  * @returns {boolean} True if condition is satisfied, false otherwise
  *
@@ -703,9 +703,9 @@ function checkCondition(condition, state) {
 
     // Future condition types can be added here:
     // case "MONEY":
-    //   return state.money >= condition.count;
+    //   return state.money >= condition.target;
     // case "PROJECTS_COMPLETED":
-    //   return Object.values(state.freelanceProjectsCompleted).reduce((sum, count) => sum + count, 0) >= condition.count;
+    //   return Object.values(state.freelanceProjectsCompleted).reduce((sum, count) => sum + count, 0) >= condition.target;
 
     default:
       // Unknown condition type—this indicates a config error (typo or invalid type).
@@ -880,7 +880,7 @@ export function isEmployeeUnlocked(employeeType, state) {
 /**
  * Calculates progress toward unlocking an employee.
  *
- * For each unlock condition, returns: current value, required value, and remaining.
+ * For each unlock condition, returns: current value, target value, and remaining.
  * Used by LockedEmployeeCard to display progress bars and remaining counts.
  *
  * @param {string} employeeType - The employee type to check
@@ -896,7 +896,7 @@ export function isEmployeeUnlocked(employeeType, state) {
  * getUnlockProgress("senior", state)
  * // Returns: [
  * //   { type: "TOTAL_LOC", current: 2000, target: 3000, remaining: 1000 },
- * //   { type: "EMPLOYEE_COUNT", current: 5, target: 10, remaining: 5 }
+ * //   { type: "TOTAL_EMPLOYEE_COUNT", current: 5, target: 10, remaining: 5 }
  * // ]
  */
 export function getUnlockProgress(employeeType, state) {

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -923,7 +923,14 @@ export function getUnlockProgress(employeeType, state) {
         current = getTotalEmployeeCount(state);
         break;
       case "SPECIFIC_EMPLOYEE_COUNT":
-        current = state.employees[condition.employeeType].count;
+        if (condition.employeeType && state.employees[condition.employeeType]) {
+          current = state.employees[condition.employeeType].count;
+        } else {
+          console.warn(
+            `Invalid employeeType in unlock condition: ${condition.employeeType}`
+          );
+          current = 0;
+        }
         break;
       default:
         current = 0;
@@ -976,7 +983,14 @@ export function getUnlockProgressForOpenSource(projectId, state) {
         current = getTotalEmployeeCount(state);
         break;
       case "SPECIFIC_EMPLOYEE_COUNT":
-        current = state.employees[condition.employeeType].count;
+        if (condition.employeeType && state.employees[condition.employeeType]) {
+          current = state.employees[condition.employeeType].count;
+        } else {
+          console.warn(
+            `Invalid employeeType in unlock condition: ${condition.employeeType}`
+          );
+          current = 0;
+        }
         break;
       default:
         current = 0;

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -107,7 +107,7 @@ export const EMPLOYEE_CONFIGS = Object.freeze({
     Icon: BsBackpack,
     color: "brown",
     // Unlock conditions
-    unlockConditions: [{ type: "TOTAL_LOC", count: 100 }],
+    unlockConditions: [{ type: "TOTAL_LOC", target: 100 }],
     description:
       "Knows 12 JavaScript frameworks but can't center a div. Will refactor your working code because it 'wasn't dry enough'.",
   },
@@ -120,8 +120,8 @@ export const EMPLOYEE_CONFIGS = Object.freeze({
     color: "green",
     // Multiple conditions (all must be met)
     unlockConditions: [
-      { type: "TOTAL_LOC", count: 3000 },
-      { type: "TOTAL_EMPLOYEE_COUNT", count: 10 },
+      { type: "TOTAL_LOC", target: 3000 },
+      { type: "TOTAL_EMPLOYEE_COUNT", target: 10 },
     ],
     description:
       "Doesn't use a mouse. Writes code on a mechanical keyboard loud enough to wake the dead. Hates everything you just wrote.",
@@ -193,7 +193,7 @@ export const OPEN_SOURCE_PROJECTS_CONFIG = Object.freeze({
     description:
       "Why fix dependencies when you can ship the whole OS? Blocker wraps your 5KB script in a 4GB virtual environment, ensuring that if it works on your machine, it's now the Ops team's problem.",
     unlockConditions: [
-      { type: "SPECIFIC_EMPLOYEE_COUNT", employeeType: "junior", count: 5 },
+      { type: "SPECIFIC_EMPLOYEE_COUNT", employeeType: "junior", target: 5 },
     ],
     levels: [
       { locCost: 2000, bonus: { type: "PASSIVE_BOOST", value: 0.5 } },
@@ -483,8 +483,8 @@ function gameReducer(state, action) {
  *
  * For unlockType === "employee", this function calls getUnlockProgress(unlockUnit, state)
  * to obtain an array of progress conditions. Each condition is expected to have numeric
- * `current` and `required` properties; the progress for a condition is computed as
- * `condition.current / condition.required`. If any condition's progress is greater than
+ * `current` and `target` properties; the progress for a condition is computed as
+ * `condition.current / condition.target`. If any condition's progress is greater than
  * or equal to GAME_BALANCE_CONFIG.UNLOCK_VISIBILITY_THRESHOLD, the function returns true.
  *
  * For unknown unlockType values the function logs a warning and returns false.
@@ -510,8 +510,7 @@ function checkProgressAgainstThreshold(progress, threshold) {
   // Check if any condition meets or exceeds the threshold
   return progress.some(
     (condition) =>
-      condition.required > 0 &&
-      condition.current / condition.required >= threshold
+      condition.target > 0 && condition.current / condition.target >= threshold
   );
 }
 // Checks if an unlockable has crossed the visibility threshold
@@ -693,15 +692,14 @@ function checkCondition(condition, state) {
   switch (condition.type) {
     case "TOTAL_LOC":
       // Player has earned enough cumulative LOC
-      return state.totalLinesOfCode >= condition.count;
+      return state.totalLinesOfCode >= condition.target;
 
     case "TOTAL_EMPLOYEE_COUNT":
       // Player has hired enough total employees (all types combined)
-      return getTotalEmployeeCount(state) >= condition.count;
-
+      return getTotalEmployeeCount(state) >= condition.target;
     case "SPECIFIC_EMPLOYEE_COUNT":
       // Player has hired enough of a specific employee type
-      return state.employees[condition.employeeType].count >= condition.count;
+      return state.employees[condition.employeeType].count >= condition.target;
 
     // Future condition types can be added here:
     // case "MONEY":
@@ -887,18 +885,18 @@ export function isEmployeeUnlocked(employeeType, state) {
  *
  * @param {string} employeeType - The employee type to check
  * @param {Object} state - The game state
- * @returns {Array<Object>} Array of { type, current, required, remaining }
+ * @returns {Array<Object>} Array of { type, current, target, remaining }
  *
  * @example
  * getUnlockProgress("junior", state)
  * // Returns: [
- * //   { type: "TOTAL_LOC", current: 45, required: 100, remaining: 55 }
+ * //   { type: "TOTAL_LOC", current: 45, target: 100, remaining: 55 }
  * // ]
  *
  * getUnlockProgress("senior", state)
  * // Returns: [
- * //   { type: "TOTAL_LOC", current: 2000, required: 3000, remaining: 1000 },
- * //   { type: "EMPLOYEE_COUNT", current: 5, required: 10, remaining: 5 }
+ * //   { type: "TOTAL_LOC", current: 2000, target: 3000, remaining: 1000 },
+ * //   { type: "EMPLOYEE_COUNT", current: 5, target: 10, remaining: 5 }
  * // ]
  */
 export function getUnlockProgress(employeeType, state) {
@@ -936,13 +934,13 @@ export function getUnlockProgress(employeeType, state) {
         current = 0;
     }
 
-    const required = condition.count;
-    const remaining = Math.max(0, required - current);
+    const target = condition.target;
+    const remaining = Math.max(0, target - current);
 
     return {
       type: condition.type,
       current,
-      required,
+      target,
       remaining,
       ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
         employeeType: condition.employeeType,
@@ -959,7 +957,7 @@ export function getUnlockProgress(employeeType, state) {
  *
  * @param {string} projectId - The project ID (e.g., "blocker")
  * @param {Object} state - The game state
- * @returns {Array<Object>} Array of { type, current, required, remaining }
+ * @returns {Array<Object>} Array of { type, current, target, remaining }
  */
 export function getUnlockProgressForOpenSource(projectId, state) {
   const config = OPEN_SOURCE_PROJECTS_CONFIG[projectId];
@@ -996,13 +994,13 @@ export function getUnlockProgressForOpenSource(projectId, state) {
         current = 0;
     }
 
-    const required = condition.count; // Note: uses 'count' not 'value' like employees
-    const remaining = Math.max(0, required - current);
+    const target = condition.target; // Note: uses 'target' not 'value' like employees
+    const remaining = Math.max(0, target - current);
 
     return {
       type: condition.type,
       current,
-      required,
+      target,
       remaining,
       ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
         employeeType: condition.employeeType,

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -937,6 +937,9 @@ export function getUnlockProgress(employeeType, state) {
       current,
       required,
       remaining,
+      ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
+        employeeType: condition.employeeType,
+      }),
     };
   });
 }
@@ -987,6 +990,9 @@ export function getUnlockProgressForOpenSource(projectId, state) {
       current,
       required,
       remaining,
+      ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
+        employeeType: condition.employeeType,
+      }),
     };
   });
 }

--- a/client/src/context/GameContext.jsx
+++ b/client/src/context/GameContext.jsx
@@ -944,6 +944,7 @@ export function getUnlockProgress(employeeType, state) {
       remaining,
       ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
         employeeType: condition.employeeType,
+        employeeName: EMPLOYEE_CONFIGS[condition.employeeType].name,
       }),
     };
   });
@@ -1004,6 +1005,7 @@ export function getUnlockProgressForOpenSource(projectId, state) {
       remaining,
       ...(condition.type === "SPECIFIC_EMPLOYEE_COUNT" && {
         employeeType: condition.employeeType,
+        employeeName: EMPLOYEE_CONFIGS[condition.employeeType].name,
       }),
     };
   });

--- a/client/src/utils/formatCondition.js
+++ b/client/src/utils/formatCondition.js
@@ -2,12 +2,12 @@
 const formatCondition = (condition) => {
   switch (condition.type) {
     case "TOTAL_LOC":
-      return `Earn ${condition.required} total lines of code`;
+      return `Earn ${condition.target} total lines of code`;
     case "TOTAL_EMPLOYEE_COUNT":
-      return `Hire ${condition.required} employees`;
+      return `Hire ${condition.target} employees`;
     case "SPECIFIC_EMPLOYEE_COUNT":
-      return `Hire ${condition.required} ${condition.employeeType}${
-        condition.required > 1 ? "s" : ""
+      return `Hire ${condition.target} ${condition.employeeType}${
+        condition.target > 1 ? "s" : ""
       }`;
     default:
       return "Complete an unknown objective";

--- a/client/src/utils/formatCondition.js
+++ b/client/src/utils/formatCondition.js
@@ -1,0 +1,17 @@
+// Format unlock condition for human-readable display
+const formatCondition = (condition) => {
+  switch (condition.type) {
+    case "TOTAL_LOC":
+      return `Earn ${condition.required} total lines of code`;
+    case "TOTAL_EMPLOYEE_COUNT":
+      return `Hire ${condition.required} employees`;
+    case "SPECIFIC_EMPLOYEE_COUNT":
+      return `Hire ${condition.required} ${condition.employeeType}${
+        condition.required > 1 ? "s" : ""
+      }`;
+    default:
+      return "Complete an unknown objective";
+  }
+};
+
+export { formatCondition };

--- a/client/src/utils/formatCondition.js
+++ b/client/src/utils/formatCondition.js
@@ -6,7 +6,7 @@ const formatCondition = (condition) => {
     case "TOTAL_EMPLOYEE_COUNT":
       return `Hire ${condition.target} employees`;
     case "SPECIFIC_EMPLOYEE_COUNT":
-      return `Hire ${condition.target} ${condition.employeeType}${
+      return `Hire ${condition.target} ${condition.employeeName}${
         condition.target > 1 ? "s" : ""
       }`;
     default:


### PR DESCRIPTION
Makes the open source card unlock work correctly, creates seperate cases for all total employee count, and specific employee type count. Adds fixed width on desktop to the statdisplay components so that when the number changes, the width of the header container doesn't bounce around.